### PR TITLE
Update fmt dependency to version 10.2.1 to solve conflicting dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@ class PividConan(conan.ConanFile):
 
     requires = [
         "cli11/2.3.2", "cpp-httplib/0.14.1",
-        "ffmpeg/5.1.4+rpi@pivid", "fmt/10.1.1",
+        "ffmpeg/5.1.4+rpi@pivid", "fmt/10.2.1",
         "linux-headers-generic/[>=5.14.9]", "nlohmann_json/3.11.3",
         "spdlog/1.12.0",
     ]


### PR DESCRIPTION
I got the following error when running ./dev_setup.py

```
ERROR: Version conflict: spdlog/1.12.0->fmt/10.2.1, pivid/0.0->fmt/10.1.1.
```

While I don't actually know about those libraries and their versions, a minor bump seemed ok and I tested it – with this change the build succeeds on Debian Bookworm 64bit (and the examples play).